### PR TITLE
Fix Python syntax error caused by a colon (:)

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,53 +1,42 @@
-import yaml
 import subprocess
+import yaml
 
-def is_python_2():
-    import sys
-
-    return sys.version_info < (3, 0):
+try:
+    input = raw_input  # Python 2
+except NameError:
+    pass               # Python 3
 
 
 def init():
-    if is_python_2() == True:
-        print 'Init inspire...'
-        public_ip = raw_input("Please enter your public ip: ")
-        public_port = raw_input("Please enter your public port(default 9010): ")
-
-    else:
-        print("Init inspire...")
-        public_ip = input("Please enter your public ip: ")
-        public_port = input("Please enter your public port(default 9010): ")
-
+    print("Init inspire...")
+    public_ip = input("Please enter your public ip: ")
+    public_port = input("Please enter your public port(default 9010): ")
     return public_ip, public_port
+
 
 def cloneIndex():
     subprocess.check_output("git clone https://github.com/super-inspire/super-inspire-frontend.git /var/", shell=True)
 
+
 def modify_yml(public_ip, public_port):
     with open("./docker-compose.yml", "r") as yaml_file:
-
         yaml_obj = yaml.safe_load(yaml_file.read())
         yaml_obj["services"]["inspire"]["environment"]["SERVERURL"] = public_ip
         yaml_obj["services"]["nginx"]["ports"] = {int(public_port):80}
 
-
     with open("./docker-compose.yml", "w") as yaml_file:
-
         yaml.dump(yaml_obj, yaml_file)
+
 
 def call_init_docker_compose():
     try:
         subprocess.check_output("chmod +x ./init.sh", shell=True)
         subprocess.check_output("./init.sh", shell=True)
     except:
-        if is_python_2():
-            print 'init.sh init fail!'
-        else:
-            print("init.sh init fail!")
+        print("init.sh init fail!")
 
 
 if __name__ == '__main__':
-
     public_ip, public_port = init()
     modify_yml(public_ip, public_port)
     call_init_docker_compose()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/super-inspire/super-inspire-end on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./init.py:7:37: E999 SyntaxError: invalid syntax
    return sys.version_info < (3, 0):
                                    ^
1     E999 SyntaxError: invalid syntax
1
```
Use __print()__ function in both Python 2 and Python 3
Redefine __input()__ in Python 2.
Follows Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).