### PR TITLE
Fix #28 操作系统图标使用 jsdelivr

### DIFF
--- a/inspire.py
+++ b/inspire.py
@@ -51,7 +51,7 @@ OS_SWITCH = {
 OS_LIST = [{
     "label": "Ubuntu",
     "value": "Ubuntu",
-    "logoUrl":"http://60.190.81.133:9010/icon/ubuntu.png",
+    "logoUrl":"https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/ubuntu.png",
     "subList":[{
         'label':"12.04",
         'osCode':"10000"
@@ -71,7 +71,7 @@ OS_LIST = [{
     ]}, {
     "label": "CentOS",
     "value": "CentOS",
-    "logoUrl":"http://60.190.81.133:9010/icon/cent-os.png",
+    "logoUrl":"https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/cent-os.png",
     "subList":[{
         'label':"6.10",
         'osCode':"20000"
@@ -86,7 +86,7 @@ OS_LIST = [{
 
     "label": "Arch Linux",
     "value": "Arch Linux",
-    "logoUrl":"http://60.190.81.133:9010/icon/arch.png",
+    "logoUrl":"https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/arch.png",
     "subList":[{
         'label':"2018.12.01",
         'osCode':"30000"
@@ -98,7 +98,7 @@ OS_LIST = [{
 
     "label": "Debian",
     "value": "Debian",
-    "logoUrl":"http://60.190.81.133:9010/icon/debain.png",
+    "logoUrl":"https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/debain.png",
     "subList":[{
         'label':"9.6.0",
         'osCode':"40000"
@@ -110,7 +110,7 @@ OS_LIST = [{
 
     "label": "Fedora",
     "value": "Fedora",
-    "logoUrl":"http://60.190.81.133:9010/icon/fedora.png",
+    "logoUrl":"https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/fedora.png",
     "subList":[{
         'label':"28",
         'osCode':"50000"
@@ -125,7 +125,7 @@ OS_LIST = [{
 
     "label": "Alpine",
     "value": "Alpine",
-    "logoUrl":"http://60.190.81.133:9010/icon/alpine.png",
+    "logoUrl":"https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/alpine.png",
     "subList":[{
         'label':"latest",
         'osCode':"60000"


### PR DESCRIPTION
发现操作系统图标都在这里：
https://github.com/super-inspire/super-inspire-end/tree/master/nginxDocker/icon

以后添加的图标也可以直接 `https://cdn.jsdelivr.net/gh/super-inspire/super-inspire-end/nginxDocker/icon/<文件名>` 使用。

Fix #28 when merged.